### PR TITLE
Update amplitude destination to retain session ID

### DIFF
--- a/lib/src/main/java/com/segment/analytics/kotlin/destinations/amplitude/AmplitudeSession.kt
+++ b/lib/src/main/java/com/segment/analytics/kotlin/destinations/amplitude/AmplitudeSession.kt
@@ -33,6 +33,7 @@ class AmplitudeSession : Plugin, VersionedPlugin {
                 message = "Running ${payload.type} payload through AmplitudeSession",
                 kind = LogFilterKind.DEBUG
             )
+            refreshSessionID()
             returnPayload =
                 payload.putIntegrations(key, mapOf("session_id" to sessionID)) as T?
         }
@@ -96,21 +97,25 @@ class AmplitudeSession : Plugin, VersionedPlugin {
     }
 
     private fun onBackground() {
-        stopTimer()
     }
 
     private fun onForeground() {
-        startTimer()
+        refreshSessionID()
     }
 
+    private fun refreshSessionID() {
+        if (sessionID == -1) {
+            // get a new session ID if we've been inactive for more than 5 min
+            sessionID = Calendar.getInstance().timeInMillis
+        }
+        startTimer()
+    }
+    
     private fun startTimer() {
-
-        // Set the session id
-        sessionID = Calendar.getInstance().timeInMillis
-
+        timer?.cancel()
         timer = Timer().schedule(fireTime) {
+            // invalidate the session ID at the end of the timer
             stopTimer()
-            startTimer()
         }
     }
 

--- a/lib/src/main/java/com/segment/analytics/kotlin/destinations/amplitude/AmplitudeSession.kt
+++ b/lib/src/main/java/com/segment/analytics/kotlin/destinations/amplitude/AmplitudeSession.kt
@@ -104,7 +104,7 @@ class AmplitudeSession : Plugin, VersionedPlugin {
     }
 
     private fun refreshSessionID() {
-        if (sessionID == -1) {
+        if (sessionID == -1L) {
             // get a new session ID if we've been inactive for more than 5 min
             sessionID = Calendar.getInstance().timeInMillis
         }

--- a/lib/src/main/java/com/segment/analytics/kotlin/destinations/amplitude/AmplitudeSession.kt
+++ b/lib/src/main/java/com/segment/analytics/kotlin/destinations/amplitude/AmplitudeSession.kt
@@ -10,7 +10,7 @@ import java.util.*
 import kotlin.concurrent.schedule
 
 // A Destination plugin that adds session tracking to Amplitude cloud mode.
-class AmplitudeSession : Plugin, VersionedPlugin {
+class AmplitudeSession (sessionTimeoutMs : Long = 300000) : Plugin, VersionedPlugin {
 
     override val type: Plugin.Type = Plugin.Type.Enrichment
     override lateinit var analytics: Analytics
@@ -19,7 +19,7 @@ class AmplitudeSession : Plugin, VersionedPlugin {
     private var active = false
 
     private var timer: TimerTask? = null
-    private val fireTime: Long = 300000
+    private val fireTime: Long = sessionTimeoutMs
 
     override fun update(settings: Settings, type: Plugin.UpdateType) {
         active = settings.hasIntegrationSettings(key)


### PR DESCRIPTION
According to amplitude docs, a session should include all events within 5 minutes of each other.  This changes the previous implementation's behavior of creating a new session ID ever 5 minutes.