### PR TITLE
LIBMOBILE-1276 - Bump up analytics-kotlin version to latest.

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -42,7 +42,7 @@ android {
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.2")
 
-    implementation("com.segment.analytics.kotlin:android:1.6.2")
+    implementation("com.segment.analytics.kotlin:android:1.10.3")
     implementation("androidx.multidex:multidex:2.0.1")
 
     implementation("androidx.core:core-ktx:1.9.0")

--- a/lib/src/main/java/com/segment/analytics/kotlin/destinations/amplitude/AmplitudeSession.kt
+++ b/lib/src/main/java/com/segment/analytics/kotlin/destinations/amplitude/AmplitudeSession.kt
@@ -3,7 +3,7 @@ package com.segment.analytics.kotlin.destinations.amplitude
 import com.segment.analytics.kotlin.core.*
 import com.segment.analytics.kotlin.core.platform.Plugin
 import com.segment.analytics.kotlin.core.platform.VersionedPlugin
-import com.segment.analytics.kotlin.core.platform.plugins.logger.LogFilterKind
+import com.segment.analytics.kotlin.core.platform.plugins.logger.LogKind
 import com.segment.analytics.kotlin.core.platform.plugins.logger.log
 import com.segment.analytics.kotlin.core.utilities.putIntegrations
 import java.util.*
@@ -31,7 +31,7 @@ class AmplitudeSession (sessionTimeoutMs : Long = 300000) : Plugin, VersionedPlu
         payload?.let {
             analytics.log(
                 message = "Running ${payload.type} payload through AmplitudeSession",
-                kind = LogFilterKind.DEBUG
+                kind = LogKind.DEBUG
             )
             refreshSessionID()
             returnPayload =


### PR DESCRIPTION
LIBMOBILE-1276
- upgraded Analytics version from 1.6.2 to 1.10.3
- replaced LogFilterKind with LogKind